### PR TITLE
fix(prod): move html-sanitizer to require, add prod e2e delivery smoke + startup diagnostics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "laminas/laminas-feed": "^2.22",
         "laminas/laminas-http": "^2.19",
         "phpmailer/phpmailer": "^7.0",
-        "sentry/sentry": "^4.7"
+        "sentry/sentry": "^4.7",
+        "symfony/html-sanitizer": "^7.0"
     },
     "require-dev": {
         "pestphp/pest": "^3.0",
@@ -33,8 +34,7 @@
         "cebe/php-openapi": "^1.8",
         "rector/rector": "^2.4",
         "phpstan/phpstan-mockery": "^2.0",
-        "symfony/options-resolver": "^7.0",
-        "symfony/html-sanitizer": "^7.0"
+        "symfony/options-resolver": "^7.0"
     },
     "scripts": {
         "test": "vendor/bin/pest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba30834fd86d81da3e8bc54bb9894e96",
+    "content-hash": "563cef4cfdd63c1b218d934edbac2e19",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -833,6 +833,255 @@
             "time": "2026-06-02T12:34:22+00:00"
         },
         {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v5.7.0",
             "source": {
@@ -1443,6 +1692,80 @@
                 }
             ],
             "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/html-sanitizer",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/html-sanitizer.git",
+                "reference": "c328df69f5b6f44a0d031d757903d955bebb23b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/c328df69f5b6f44a0d031d757903d955bebb23b3",
+                "reference": "c328df69f5b6f44a0d031d757903d955bebb23b3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri": "^6.5|^7.0",
+                "masterminds/html5": "^2.7.2",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HtmlSanitizer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "Purifier",
+                "html",
+                "sanitizer"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-06T11:10:32+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2184,188 +2507,6 @@
             "time": "2026-06-16T20:50:26+00:00"
         },
         {
-            "name": "league/uri",
-            "version": "7.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/uri.git",
-                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
-                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
-                "shasum": ""
-            },
-            "require": {
-                "league/uri-interfaces": "^7.8.1",
-                "php": "^8.1",
-                "psr/http-factory": "^1"
-            },
-            "conflict": {
-                "league/uri-schemes": "^1.0"
-            },
-            "suggest": {
-                "ext-bcmath": "to improve IPV4 host parsing",
-                "ext-dom": "to convert the URI into an HTML anchor tag",
-                "ext-fileinfo": "to create Data URI from file contennts",
-                "ext-gmp": "to improve IPV4 host parsing",
-                "ext-intl": "to handle IDN host with the best performance",
-                "ext-uri": "to use the PHP native URI class",
-                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
-                "league/uri-components": "to provide additional tools to manipulate URI objects components",
-                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
-                "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
-                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Uri\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ignace Nyamagana Butera",
-                    "email": "nyamsprod@gmail.com",
-                    "homepage": "https://nyamsprod.com"
-                }
-            ],
-            "description": "URI manipulation library",
-            "homepage": "https://uri.thephpleague.com",
-            "keywords": [
-                "URN",
-                "data-uri",
-                "file-uri",
-                "ftp",
-                "hostname",
-                "http",
-                "https",
-                "middleware",
-                "parse_str",
-                "parse_url",
-                "psr-7",
-                "query-string",
-                "querystring",
-                "rfc2141",
-                "rfc3986",
-                "rfc3987",
-                "rfc6570",
-                "rfc8141",
-                "uri",
-                "uri-template",
-                "url",
-                "ws"
-            ],
-            "support": {
-                "docs": "https://uri.thephpleague.com",
-                "forum": "https://thephpleague.slack.com",
-                "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/nyamsprod",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-03-15T20:22:25+00:00"
-        },
-        {
-            "name": "league/uri-interfaces",
-            "version": "7.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
-                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "php": "^8.1",
-                "psr/http-message": "^1.1 || ^2.0"
-            },
-            "suggest": {
-                "ext-bcmath": "to improve IPV4 host parsing",
-                "ext-gmp": "to improve IPV4 host parsing",
-                "ext-intl": "to handle IDN host with the best performance",
-                "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
-                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Uri\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ignace Nyamagana Butera",
-                    "email": "nyamsprod@gmail.com",
-                    "homepage": "https://nyamsprod.com"
-                }
-            ],
-            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
-            "homepage": "https://uri.thephpleague.com",
-            "keywords": [
-                "data-uri",
-                "file-uri",
-                "ftp",
-                "hostname",
-                "http",
-                "https",
-                "parse_str",
-                "parse_url",
-                "psr-7",
-                "query-string",
-                "querystring",
-                "rfc3986",
-                "rfc3987",
-                "rfc6570",
-                "uri",
-                "url",
-                "ws"
-            ],
-            "support": {
-                "docs": "https://uri.thephpleague.com",
-                "forum": "https://thephpleague.slack.com",
-                "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/nyamsprod",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-03-08T20:05:35+00:00"
-        },
-        {
             "name": "marc-mabe/php-enum",
             "version": "v4.7.2",
             "source": {
@@ -2437,73 +2578,6 @@
                 "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
             },
             "time": "2025-09-14T11:18:39+00:00"
-        },
-        {
-            "name": "masterminds/html5",
-            "version": "2.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Masterminds\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matt Butcher",
-                    "email": "technosophos@gmail.com"
-                },
-                {
-                    "name": "Matt Farina",
-                    "email": "matt@mattfarina.com"
-                },
-                {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                }
-            ],
-            "description": "An HTML5 parser and serializer.",
-            "homepage": "http://masterminds.github.io/html5-php",
-            "keywords": [
-                "HTML5",
-                "dom",
-                "html",
-                "parser",
-                "querypath",
-                "serializer",
-                "xml"
-            ],
-            "support": {
-                "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
-            },
-            "time": "2025-07-25T09:04:22+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -5379,80 +5453,6 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
-        },
-        {
-            "name": "symfony/html-sanitizer",
-            "version": "v7.4.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/html-sanitizer.git",
-                "reference": "761f6c49dfd103ee08b3cd09ece588b069e18ec9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/761f6c49dfd103ee08b3cd09ece588b069e18ec9",
-                "reference": "761f6c49dfd103ee08b3cd09ece588b069e18ec9",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "league/uri": "^6.5|^7.0",
-                "masterminds/html5": "^2.7.2",
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\HtmlSanitizer\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Titouan Galopin",
-                    "email": "galopintitouan@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "Purifier",
-                "html",
-                "sanitizer"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.13"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-client",

--- a/scripts/run-e2e-against-prod.sh
+++ b/scripts/run-e2e-against-prod.sh
@@ -177,14 +177,103 @@ export E2E_FEED_HOST="host.docker.internal"
 set +e
 php -d output_buffering=off vendor/bin/pest --testsuite e2e --testdox
 TEST_EXIT=$?
-set -e
+SMOKE_EXIT=0
+
+# 8b. Smoke-test the CLI delivery entrypoint inside the production container.
+# Seeds a confirmed subscription + a feed due this hour, triggers the cron,
+# and asserts the SMTP mock received the newsletter. This is the only e2e
+# coverage of bin/send-newsletters.php — the HTTP suite never exercises it.
+echo "=== 8b. Smoke-testing CLI delivery (bin/send-newsletters.php) ==="
+export E2E_FEED_URI="http://host.docker.internal:9995/valid.xml"
+export E2E_SUB_EMAIL="delivery-test@example.com"
+# trigger_hour must equal the in-container current hour for getScheduled() to
+# pick the feed up; the cron uses new \DateTimeImmutable() under the
+# production timezone (America/Argentina/Buenos_Aires), so read it from there.
+TRIGGER_HOUR="$(docker compose -f compose-e2e.yaml exec -T prod php -r 'echo (int)(new \DateTimeImmutable())->format("H");' 2>/dev/null | tr -dc '0-9')"
+if [ -z "$TRIGGER_HOUR" ]; then
+    echo "FAIL: could not read current hour from container" >&2
+    SMOKE_EXIT=1
+else
+    TRIGGER_HOUR=$(( 10#$TRIGGER_HOUR ))
+    export E2E_TRIGGER_HOUR="$TRIGGER_HOUR"
+    php -r '
+        $dbPath = getenv("NEWSLETTER_DB_PATH");
+        $feedUri = getenv("E2E_FEED_URI");
+        $subEmail = getenv("E2E_SUB_EMAIL");
+        $triggerHour = (int) getenv("E2E_TRIGGER_HOUR");
+        $pdo = new PDO("sqlite:" . $dbPath);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("DELETE FROM subscriptions");
+        $pdo->exec("DELETE FROM feeds");
+        $pdo->prepare("INSERT INTO feeds (uri, title, link, last_update, trigger_hour, last_sent_post_uri) VALUES (?, ?, ?, ?, ?, NULL)")
+            ->execute([$feedUri, "Test Blog", "https://example.com", time(), $triggerHour]);
+        $pdo->prepare("INSERT INTO subscriptions (feed_uri, email, active) VALUES (?, ?, 1)")
+            ->execute([$feedUri, $subEmail]);
+        echo "   ✓ Seeded confirmed subscription + feed due hour {$triggerHour}\n";
+    '
+    if [ $? -ne 0 ]; then
+        echo "FAIL: DB seed failed" >&2
+        SMOKE_EXIT=1
+    else
+        SMTP_BEFORE="$(wc -l < /tmp/smtp-mock-prod.log 2>/dev/null | tr -dc '0-9')"
+        SMTP_BEFORE="${SMTP_BEFORE:-0}"
+        # Run the cron inside the production container (the real delivery path).
+        docker compose -f compose-e2e.yaml exec -T prod php /app/bin/send-newsletters.php >/tmp/cron-prod.log 2>&1
+        # The script swallows exceptions and always exits 0, so assert by effect:
+        # the SMTP mock must have logged a delivery to the subscriber.
+        sleep 1
+        if tail -n +"$((SMTP_BEFORE + 1))" /tmp/smtp-mock-prod.log 2>/dev/null | grep -q "To:.*$E2E_SUB_EMAIL"; then
+            echo "   ✓ Newsletter delivered to SMTP mock"
+        else
+            echo "FAIL: cron ran but no email to $E2E_SUB_EMAIL in SMTP mock log" >&2
+            echo "   --- cron output ---" >&2
+            cat /tmp/cron-prod.log >&2
+            echo "   --- smtp mock log (tail) ---" >&2
+            tail -20 /tmp/smtp-mock-prod.log >&2
+            SMOKE_EXIT=1
+        fi
+    fi
+fi
+
+# 8c. Assert clean PHP startup inside the production container — no failed
+# extension loads, startup warnings, or notices. A regression like the
+# opcache.so one (broken zend_extension in production.ini) is invisible to the
+# HTTP suite because display_startup_errors=Off keeps it out of HTTP responses;
+# this step surfaces it from the container logs and a direct CLI probe.
+echo "=== 8c. Checking for PHP startup diagnostics ==="
+STARTUP_ERR="$(docker compose -f compose-e2e.yaml exec -T prod php -r 'echo "php-ok";' 2>&1)"
+if printf '%s\n' "$STARTUP_ERR" | grep -qE 'PHP (Warning|Notice|Parse error|Fatal error|Deprecated):|Failed loading (Zend )?extension'; then
+    echo "FAIL: PHP emitted startup diagnostics:" >&2
+    printf '%s\n' "$STARTUP_ERR" >&2
+    SMOKE_EXIT=1
+else
+    echo "   ✓ No PHP startup diagnostics"
+fi
+# Also scan the container's own logs for startup warnings emitted by the
+# FrankenPHP worker since boot.
+if docker compose -f compose-e2e.yaml logs --no-color prod 2>&1 | grep -qE 'PHP (Warning|Notice|Parse error|Fatal error):|Failed loading (Zend )?extension'; then
+    echo "FAIL: production container logs contain PHP startup diagnostics:" >&2
+    docker compose -f compose-e2e.yaml logs --no-color prod 2>&1 | grep -E 'PHP (Warning|Notice|Parse error|Fatal error):|Failed loading (Zend )?extension' >&2
+    SMOKE_EXIT=1
+else
+    echo "   ✓ Container logs clean of PHP startup diagnostics"
+fi
+
 
 echo ""
 echo "=========================================="
-if [ "$TEST_EXIT" -eq 0 ]; then
-    echo "✓ All E2E tests passed against the production container"
-else
+FINAL_EXIT=0
+if [ "$TEST_EXIT" -ne 0 ]; then
     echo "✗ E2E tests failed with exit code: $TEST_EXIT"
+    FINAL_EXIT=1
+else
+    echo "✓ All E2E tests passed against the production container"
+fi
+if [ "$SMOKE_EXIT" -ne 0 ]; then
+    echo "✗ Production smoke checks failed (CLI delivery and/or PHP startup diagnostics)" >&2
+    FINAL_EXIT=1
+else
+    echo "✓ Production smoke checks passed (CLI delivery + clean PHP startup)"
 fi
 
-exit "$TEST_EXIT"
+exit "$FINAL_EXIT"


### PR DESCRIPTION
## Fix + test coverage for the production newsletter delivery path

Fixes the actual root cause of `Newsletter delivery failed: A technical error occurred. Please try again later.` from `bin/send-newsletters.php` under the production image, and adds the e2e coverage that would have caught both this bug and the previous opcache regression.

### Root cause

`symfony/html-sanitizer` was classified as a **`require-dev`** dependency, but it is a **runtime** dependency of `FeedImporterLaminas::fetchWithPosts()` — the cron delivery path:

```php
// libs/Adapters/FeedImporterLaminas.php
use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;

public function fetchWithPosts(Feed $feed): Feed {
    ...
    $config = new HtmlSanitizerConfig();   // <-- fatal in prod
    $sanitizer = new HtmlSanitizer($config);
    ...
}
```

The production `Dockerfile` runs `composer install --no-dev`, so the `HtmlSanitizer` classes were **absent from the production image** → fatal `Class not found` on every scheduled delivery → caught by `send-newsletters.php`'s `Throwable` handler → logged as `Newsletter delivery failed: A technical error occurred. Please try again later.`

This was invisible to every existing test:
- **Unit tests** run with dev deps and never call `fetchWithPosts`.
- **E2e HTTP suite** only exercises the subscribe flow, which calls `fetchNew()`, never `fetchWithPosts()`.
- **The devcontainer** runs `composer install` **with** dev deps, so the class is present locally.

**Fix:** move `symfony/html-sanitizer` from `require-dev` to `require` in `composer.json`.

### New e2e coverage in `run-e2e-against-prod.sh`

The `e2e-prod-tests` CI job is the only job that builds and runs the production (`--no-dev`) image, so it's the right place for these smoke checks.

**8b. CLI delivery smoke** — the only runtime coverage of `bin/send-newsletters.php`. Seeds a confirmed subscription + a feed due at the current hour (timezone read from the container to match `FeedsDAO::getScheduled()`), runs the cron inside the prod container, and asserts the SMTP mock received the newsletter. Asserts by effect because the cron swallows exceptions and always exits 0. This is exactly the boundary that exposes misclassified prod deps — it caught this bug on its first run.

**8c. PHP startup diagnostics** — probes `php` inside the container and scans the container logs for failed extension loads / startup warnings. Would have caught the `zend_extension=opcache.so` regression (the `.so` doesn't exist in the frankenphp binary — OPcache is statically compiled; fixed in the previous commit #3bb48de). That warning was invisible to the HTTP suite because `display_startup_errors = Off` keeps it out of HTTP responses.

Both smoke checks gate the runner exit: `FINAL_EXIT = TEST_EXIT || SMOKE_EXIT`.

### Verification

End-to-end run of `scripts/run-e2e-against-prod.sh` (rebuilt the production image from scratch):

```
=== 8. Running e2e suite ===
Tests: 15, Assertions: 32, PHPUnit Warnings: 1.
=== 8b. Smoke-testing CLI delivery (bin/send-newsletters.php) ===
   ✓ Seeded confirmed subscription + feed due hour 17
   ✓ Newsletter delivered to SMTP mock
=== 8c. Checking for PHP startup diagnostics ===
   ✓ No PHP startup diagnostics
   ✓ Container logs clean of PHP startup diagnostics

✓ All E2E tests passed against the production container
✓ Production smoke checks passed (CLI delivery + clean PHP startup)
```

- Unit/integration suite (`--testsuite=default`): ✅ exit 0
- `composer validate --strict`: ✅

### Files changed

- `composer.json` / `composer.lock` — move `symfony/html-sanitizer` to `require`.
- `scripts/run-e2e-against-prod.sh` — add CLI delivery smoke (8b) + PHP startup diagnostics check (8c), gating exit.

### Related

Builds on the opcache `.ini` fix from #3bb48de (`fix(php): update OPcache configuration comments to clarify usage`), which removed the broken `zend_extension=opcache.so` directive. This PR fixes the *actual* delivery failure behind that warning.