### PR TITLE
fix(db): restore file-based DB fallback, regression broke prod to :memory:

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 return (
     /** @return array<string, string> */
     static function (): array {
-        $dbPath = \getenv('NEWSLETTER_DB_PATH');
+        $dbPath = \getenv('NEWSLETTER_DB_PATH') ?: __DIR__ . '/../data/database.sqlite3';
         return [
-            'dsn' => 'sqlite:' . (\is_string($dbPath) ? $dbPath : ':memory:'),
+            'dsn' => 'sqlite:' . $dbPath,
         ];
     }
 )();

--- a/tests/DatabaseConfigTest.php
+++ b/tests/DatabaseConfigTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+test('database config falls back to the file DB when NEWSLETTER_DB_PATH is not set', function (): void {
+    $previous = \getenv('NEWSLETTER_DB_PATH');
+    \putenv('NEWSLETTER_DB_PATH');
+
+    try {
+        /** @var array{dsn: string} $config */
+        $config = require __DIR__ . '/../config/database.php';
+    } finally {
+        if ($previous !== false) {
+            \putenv('NEWSLETTER_DB_PATH=' . $previous);
+        }
+    }
+
+    expect($config['dsn'])->toStartWith('sqlite:')
+        ->and($config['dsn'])->toContain('data/database.sqlite3')
+        ->and($config['dsn'])->not->toContain(':memory:');
+});
+
+test('database config honors NEWSLETTER_DB_PATH when set', function (): void {
+    $previous = \getenv('NEWSLETTER_DB_PATH');
+    \putenv('NEWSLETTER_DB_PATH=/tmp/custom-newsletter.db');
+
+    try {
+        /** @var array{dsn: string} $config */
+        $config = require __DIR__ . '/../config/database.php';
+    } finally {
+        if ($previous !== false) {
+            \putenv('NEWSLETTER_DB_PATH=' . $previous);
+        }
+    }
+
+    expect($config['dsn'])->toBe('sqlite:/tmp/custom-newsletter.db');
+});


### PR DESCRIPTION
## Problem

Every subscription request on production returns HTTP 400 with "Error: Invalid data / A technical error occurred. Please try again later." — e.g. `GET /v1/subscriptions/?return=...&uri=https://daily-knowledge.iyaki.ar/feed.xml&email=...`.

The feed itself is valid (confirmed by fetching it); the failure is a database regression:

- Commit `7b5d355` (mago lint fixes, 2026-06-15) rewrote `config/database.php` and replaced the `data/database.sqlite3` fallback with `:memory:`.
- `compose-prod.yaml` never sets `NEWSLETTER_DB_PATH` (it mounts `./data:/app/data`), so production connects to a fresh in-memory SQLite with **no tables**.
- First DB access — the rate limiter's `rate_limits` query — throws `PDOException: no such table: rate_limits`, caught and surfaced as the generic "A technical error occurred." 400 page.

Reproduced locally: pre-fix config fails with `no such table: rate_limits` and the identical user-facing message.

## Fix

`config/database.php` restores the pre-regression fallback:

```php
$dbPath = \getenv('NEWSLETTER_DB_PATH') ?: __DIR__ . '/../data/database.sqlite3';
```

## Verification

- HTTP smoke test of the reported URL against the fixed code: request passes the rate limiter, fetches the real feed, inserts feed + subscription into the file DB, and proceeds to SMTP (only step that fails locally — no SMTP server in the sandbox; production configures it via `.env`).
- Added `tests/DatabaseConfigTest.php` guarding the fallback contract (env set → honored; unset → file DB, not `:memory:`).
- Test suite: 116 passed, 1 pre-existing risky (no assertions). `FeedImporterLaminasTest` excluded — fails identically on a clean tree (sandbox cannot spawn `php -S` via Symfony Process).
- `phpstan` and `mago` clean on the changed file.

## Deploy note

After deploy the app uses the mounted host DB at `/app/data/database.sqlite3`. If that file predates June 2026, verify it has the `rate_limits` table (`migrations/03-rate-limiting.sql`); otherwise the rate limiter throws the same wrapped error.