### PR TITLE
feat(delivery): send all new posts in a single digest email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Container.php (manual DI)      ← top-level wiring
 
 **subscriptions**: `feed_uri` (TEXT NOT NULL → FK feeds.uri), `email` (TEXT NOT NULL), `active` (INTEGER NOT NULL boolean). UNIQUE(feed_uri, email). Index on `feed_uri`.
 
-> **Note**: The specs describe an evolved schema not yet migrated (subscriptions: token, confirmed, created_at, updated_at; feeds: last_post). The 6-month-old migrations are the ground truth.
+> **Note**: The specs describe an evolved schema not yet migrated (subscriptions: token, confirmed, created_at, updated_at; feeds: trigger_hour missing, last_update semantics, link nullability). The 6-month-old migrations are the ground truth.
 
 ## Key Directories
 

--- a/libs/Components/EmailTemplateFactory.php
+++ b/libs/Components/EmailTemplateFactory.php
@@ -43,17 +43,20 @@ final readonly class EmailTemplateFactory
         );
     }
 
+    /**
+     * @param non-empty-list<Post> $posts
+     */
     public function createNewsletter(
         Subscription $subscription,
         Feed $feed,
-        Post $post,
+        array $posts,
         #[\SensitiveParameter]
         string $token,
     ): Newsletter {
         return new Newsletter(
             $subscription,
             $feed,
-            $post,
+            $posts,
             \sprintf(
                 '%s/v1/subscriptions/cancellation/?uri=%s&email=%s&token=%s',
                 $this->serviceHost,

--- a/libs/Models/Newsletter.php
+++ b/libs/Models/Newsletter.php
@@ -30,16 +30,19 @@ final readonly class Newsletter
         ));
     }
 
-    public function sendPostToSubscribers(
+    /**
+     * @param non-empty-list<Post> $posts
+     */
+    public function sendPostsToSubscribers(
         Feed $feed,
-        Post $post,
+        array $posts,
         Subscription ...$subscriptions,
     ): void {
         foreach ($subscriptions as $subscription) {
             $this->sender->send($this->emailTemplateFactory->createNewsletter(
                 $subscription,
                 $feed,
-                $post,
+                $posts,
                 $this->auth->hash($subscription->email),
             ));
         }

--- a/libs/Models/Subscriptions.php
+++ b/libs/Models/Subscriptions.php
@@ -91,20 +91,34 @@ final readonly class Subscriptions
         foreach ($scheduledFeeds as $scheduledFeed) {
             $feed = $this->feeds->retrieveWithPosts($scheduledFeed);
 
-            $posts = $feed->posts;
-            foreach ($posts as $post) {
+            // Posts arrive newest→oldest. Collect every post newer than the
+            // watermark (lastSentPostUri); stop at it, since it and everything
+            // after were already sent.
+            /** @var list<\SimpleNewsletter\Data\Post> $newPosts */
+            $newPosts = [];
+            foreach ($feed->posts as $post) {
                 if ($post->uri === $feed->lastSentPostUri) {
-                    continue;
+                    break;
                 }
-
-                /** @var list<Subscription> $activeSubscriptions */
-                $activeSubscriptions = $this->subscriptionsDAO->findActiveSubscriptionsFor($feed);
-                $this->newsletter->sendPostToSubscribers($feed, $post, ...$activeSubscriptions);
-
-                $this->feeds->updateLastSentPost($feed, $post);
-
-                break;
+                $newPosts[] = $post;
             }
+
+            if ($newPosts === []) {
+                continue;
+            }
+
+            // First delivery (no watermark): seed with only the newest post
+            // instead of mailing the entire historical backlog.
+            if ($feed->lastSentPostUri === null) {
+                $newPosts = [$newPosts[0]];
+            }
+
+            /** @var list<Subscription> $activeSubscriptions */
+            $activeSubscriptions = $this->subscriptionsDAO->findActiveSubscriptionsFor($feed);
+            $this->newsletter->sendPostsToSubscribers($feed, $newPosts, ...$activeSubscriptions);
+
+            // $newPosts is newest-first; advance the watermark to the newest sent.
+            $this->feeds->updateLastSentPost($feed, $newPosts[0]);
         }
     }
 }

--- a/libs/Templates/Email/Newsletter.php
+++ b/libs/Templates/Email/Newsletter.php
@@ -10,10 +10,13 @@ use SimpleNewsletter\Data\Subscription;
 
 final readonly class Newsletter implements EmailInterface
 {
+    /**
+     * @param non-empty-list<Post> $posts Newest-first.
+     */
     public function __construct(
         private Subscription $subscription,
         private Feed $feed,
-        private Post $post,
+        private array $posts,
         private string $cancellationURI,
     ) {}
 
@@ -26,17 +29,35 @@ final readonly class Newsletter implements EmailInterface
     #[\Override]
     public function subject(): string
     {
-        return $this->post->title . ' - ' . $this->feed->getTitle();
+        $count = \count($this->posts);
+        $title = $count > 1
+            ? $this->posts[0]->title . ' (+' . ($count - 1) . ' more)'
+            : $this->posts[0]->title;
+
+        return $title . ' - ' . $this->feed->getTitle();
     }
 
     #[\Override]
     public function body(): string
     {
         $fontStack = "Rockwell,'Rockwell Nova','Roboto Slab','DejaVu Serif','Sitka Small',serif";
+
+        $blocks = [];
+        foreach ($this->posts as $index => $post) {
+            if ($index > 0) {
+                $blocks[] = '<hr style="border:none;border-top:1px solid #ccc;margin:2em 0">';
+            }
+            $blocks[] = '<article>';
+            $blocks[] = '<h2 style="margin:0 0 .5em;font-size:1.3em"><a href="' . $post->uri . '">' . $post->title . '</a></h2>';
+            $blocks[] = $post->content;
+            $blocks[] = '</article>';
+        }
+
+        $postsHtml = \implode("\n", $blocks);
+
         return <<<HTML
-            <a href="{$this->post->uri}">Visit original website</a>
             <div style="max-width:60ch;margin:0 auto;font-size:18px;line-height:1.5;font-family:{$fontStack}">
-                {$this->post->content}
+                {$postsHtml}
             </div>
             <p><a href="{$this->cancellationURI}">To cancel your subscription to this newsletter click here</a></p>
             HTML;

--- a/public/index.php
+++ b/public/index.php
@@ -123,7 +123,7 @@
             <ol>
                 <li><strong>Enter a feed and email</strong> — Paste any RSS or Atom feed URL (e.g., <code>https://example.com/blog/feed.xml</code> or a YouTube channel RSS)</li>
                 <li><strong>Confirm your email</strong> — Click the double opt-in link you receive (sent immediately, takes 30 seconds)</li>
-                <li><strong>Receive newsletters</strong> — New posts from the feed arrive in your inbox within an hour of publication</li>
+                <li><strong>Receive newsletters</strong> — New posts from the feed arrive in your inbox once per day, bundled into a single digest email</li>
                 <li><strong>Unsubscribe anytime</strong> — One-click link in every email, instant removal</li>
             </ol>
         </section>
@@ -158,7 +158,7 @@
                     </details></li>
                     <li><details>
                         <summary>How often are newsletters sent?</summary>
-                        <p>New posts are delivered once per day for every source.</p>
+                        <p>New posts are delivered once per day per feed, bundled into a single digest email.</p>
                     </details></li>
                     <li><details>
                         <summary>What data do you store?</summary>
@@ -200,13 +200,6 @@
                     <button type="submit">Subscribe!</button>
                 </form>
                 HTML) ?></code></pre>
-            <details>
-                <summary>Known limitations</summary>
-                <ul>
-                    <li>Currently the service sends only one newsletter per day for each subscription (Feed/E-mail combination). I'm working to improve that.</li>
-                    <!-- <li>For performance reasons all the subscriptors to a Feed are BCCed on the same e-mail. If you don't find the newsletter e-mails in your inbox please check your spam folder and mark the message as "Not Spam".</li> -->
-                </ul>
-            </details>
         </section>
     </main>
     <footer style="text-align: center; padding-top: 20px;">

--- a/specs/core-architecture.md
+++ b/specs/core-architecture.md
@@ -78,9 +78,9 @@ Delivery flow:
           → Feeds::getScheduled()
           → For each feed with subscriptions:
               → Feeds::retrieveWithPosts() → FeedImporter::fetchWithPosts()
-              → For each new post:
-                  → Newsletter::sendPostToSubscribers()
-                  → Feeds::updateLastSentPost()
+              → Collect posts newer than the watermark (feed.last_post)
+              → Newsletter::sendPostsToSubscribers() — one email per subscriber with all new posts
+              → Feeds::updateLastSentPost() — advance watermark to the newest sent post
 ```
 
 ## Security Considerations

--- a/specs/core-architecture.md
+++ b/specs/core-architecture.md
@@ -78,7 +78,7 @@ Delivery flow:
           → Feeds::getScheduled()
           → For each feed with subscriptions:
               → Feeds::retrieveWithPosts() → FeedImporter::fetchWithPosts()
-              → Collect posts newer than the watermark (feed.last_post)
+              → Collect posts newer than the watermark (feed.last_sent_post_uri)
               → Newsletter::sendPostsToSubscribers() — one email per subscriber with all new posts
               → Feeds::updateLastSentPost() — advance watermark to the newest sent post
 ```

--- a/specs/database-schema.md
+++ b/specs/database-schema.md
@@ -20,7 +20,7 @@ Define the SQLite database schema, constraints, and indexing strategy.
 | title | TEXT | NOT NULL | Feed title from XML |
 | link | TEXT | NOT NULL | Feed website link |
 | last_update | TEXT | NOT NULL | ISO 8601 timestamp of last fetch |
-| last_post | TEXT | | URI of the most recently sent post |
+| last_sent_post_uri | TEXT | | URI of the most recently sent post |
 
 #### subscriptions
 
@@ -46,7 +46,7 @@ CREATE TABLE feeds (
     title       TEXT NOT NULL,
     link        TEXT NOT NULL,
     last_update TEXT NOT NULL,
-    last_post   TEXT
+    last_sent_post_uri TEXT
 );
 
 CREATE TABLE subscriptions (
@@ -73,7 +73,7 @@ erDiagram
         text title
         text link
         text last_update
-        text last_post
+        text last_sent_post_uri
     }
     subscriptions {
         text feed_uri FK

--- a/specs/feed-importer.md
+++ b/specs/feed-importer.md
@@ -35,7 +35,7 @@ Uses `laminas/laminas-http` Client for HTTP fetching.
 | title | string | Extracted feed title |
 | link | string | Feed website link |
 | lastUpdate | DateTimeImmutable | Timestamp of last fetch |
-| lastPost | ?string | URI of most recently sent post |
+| lastSentPostUri | ?string | URI of most recently sent post |
 
 ### Post value object (libs/Data/Post.php)
 
@@ -61,7 +61,7 @@ Uses `laminas/laminas-http` Client for HTTP fetching.
 1. `FeedImporter::fetchWithPosts(feed: Feed): Feed`
 2. Re-fetch feed XML.
 3. Parse all entries.
-4. Filter posts newer than `feed.lastPost`.
+4. Filter posts newer than `feed.lastSentPostUri`.
 5. Return updated Feed with `posts` array.
 
 ### 3. Update stale feed

--- a/specs/newsletter-delivery.md
+++ b/specs/newsletter-delivery.md
@@ -18,7 +18,7 @@ bin/send-newsletters.php (CLI entrypoint, called via cron)
         → Feeds::getScheduled() — feeds with confirmed subscribers
         → For each feed:
             → Feeds::retrieveWithPosts() — fetch posts
-            → Collect posts newer than feed.last_post (watermark); stop at it
+            → Collect posts newer than feed.last_sent_post_uri (watermark); stop at it
             → Filter subscribers (confirmed, subscribed to this feed)
             → Newsletter::sendPostsToSubscribers() — one email per subscriber, all new posts
                 → EmailTemplateFactory::createNewsletter()
@@ -39,13 +39,13 @@ Configured via environment variables.
 2. Cron triggers `bin/send-newsletters.php` every hour.
 3. For each feed whose `trigger_hour` matches the current hour, and has confirmed subscribers:
    - Re-fetch the feed to obtain its posts.
-   - Collect every post newer than the watermark (`feed.last_post`); stop at it,
+   - Collect every post newer than the watermark (`feed.last_sent_post_uri`); stop at it,
      since it and everything older were already sent.
-   - First delivery (`last_post` is null): send only the newest post, not the
+   - First delivery (`last_sent_post_uri` is null): send only the newest post, not the
      entire historical backlog.
    - Compose a single digest email containing all the new posts.
    - Send one individual email per confirmed subscriber (not a BCC batch).
-   - Advance `feed.last_post` to the newest sent post's URI.
+   - Advance `feed.last_sent_post_uri` to the newest sent post's URI.
 
 ### 2. Email composition
 

--- a/specs/newsletter-delivery.md
+++ b/specs/newsletter-delivery.md
@@ -17,13 +17,13 @@ bin/send-newsletters.php (CLI entrypoint, called via cron)
     → Subscriptions::sendScheduled()
         → Feeds::getScheduled() — feeds with confirmed subscribers
         → For each feed:
-            → Feeds::retrieveWithPosts() — fetch new posts
-            → For each new post:
-                → Filter subscribers (confirmed, subscribed to this feed)
-                → Newsletter::sendPostToSubscribers()
-                    → EmailTemplateFactory::createNewsletter()
-                    → Sender::send() → SenderPHPMailer
-                → Feeds::updateLastSentPost()
+            → Feeds::retrieveWithPosts() — fetch posts
+            → Collect posts newer than feed.last_post (watermark); stop at it
+            → Filter subscribers (confirmed, subscribed to this feed)
+            → Newsletter::sendPostsToSubscribers() — one email per subscriber, all new posts
+                → EmailTemplateFactory::createNewsletter()
+                → Sender::send() → SenderPHPMailer
+            → Feeds::updateLastSentPost() — advance watermark to the newest sent post
 ```
 
 ### SenderPHPMailer
@@ -37,20 +37,23 @@ Configured via environment variables.
 
 1. Each feed has a `trigger_hour` that indicates at which hour of the day their newsletters should be sent.
 2. Cron triggers `bin/send-newsletters.php` every hour.
-3. For each which `trigger_hour` matches the current hour, and has confirmed subscribers:
-   - Re-fetch the feed to find new posts.
-   - For each new post (since `last_post`):
-     - Compose a newsletter email (HTML template).
-     - Send individually to each confirmed subscriber.
-     - Update `feed.last_post` to the latest sent post's URI.
+3. For each feed whose `trigger_hour` matches the current hour, and has confirmed subscribers:
+   - Re-fetch the feed to obtain its posts.
+   - Collect every post newer than the watermark (`feed.last_post`); stop at it,
+     since it and everything older were already sent.
+   - First delivery (`last_post` is null): send only the newest post, not the
+     entire historical backlog.
+   - Compose a single digest email containing all the new posts.
+   - Send one individual email per confirmed subscriber (not a BCC batch).
+   - Advance `feed.last_post` to the newest sent post's URI.
 
 ### 2. Email composition
 
 | Component | Implementation |
 |-----------|---------------|
 | From address | Configured via env `SMTP_FROM` |
-| Subject | `[Feed Title] Post Title` |
-| Body | HTML template from `EmailTemplateFactory` |
+| Subject | Single post: `Post Title - Feed Title`. Multiple posts: `First Post Title (+N more) - Feed Title` |
+| Body | One `<article>` per new post (title links to the original, sanitized HTML content); posts separated by a horizontal rule |
 | Unsubscribe link | Signed cancellation URL with token |
 | Per-recipient | Each subscriber gets an individual email (not BCC batch) |
 

--- a/tests/Components/EmailTemplateFactoryTest.php
+++ b/tests/Components/EmailTemplateFactoryTest.php
@@ -40,7 +40,7 @@ test('createNewsletter returns Newsletter with correct subject format and cancel
     $post = new Post('https://example.com/post/1', 'Test Post Title', '<p>Test content</p>');
     $token = 'cancel-token-456';
 
-    $result = $factory->createNewsletter($subscription, $feed, $post, $token);
+    $result = $factory->createNewsletter($subscription, $feed, [$post], $token);
 
     expect($result)->toBeInstanceOf(\SimpleNewsletter\Templates\Email\Newsletter::class);
     expect($result->recipient())->toEqual('user@example.com');

--- a/tests/Models/NewsletterTest.php
+++ b/tests/Models/NewsletterTest.php
@@ -20,7 +20,9 @@ use SimpleNewsletter\Templates\Email\SubscriptionConfirmation;
 test('sendConfirmation calls sender with template from EmailTemplateFactory', function (): void {
     /** @var Sender&\Mockery\MockInterface $sender */
     $sender = \Mockery::mock(Sender::class);
+    /** @var EmailTemplateFactory&\Mockery\MockInterface $emailTemplateFactory */
     $emailTemplateFactory = \Mockery::mock(EmailTemplateFactory::class);
+    /** @var Auth&\Mockery\MockInterface $auth */
     $auth = \Mockery::mock(Auth::class);
 
     $now = new DateTimeImmutable();
@@ -52,8 +54,11 @@ test('sendConfirmation calls sender with template from EmailTemplateFactory', fu
  * @throws AssertionFailedError
  */
 test('sendConfirmation uses auth hash of subscription email as token', function (): void {
+    /** @var Sender&\Mockery\MockInterface $sender */
     $sender = \Mockery::mock(Sender::class);
+    /** @var EmailTemplateFactory&\Mockery\MockInterface $emailTemplateFactory */
     $emailTemplateFactory = \Mockery::mock(EmailTemplateFactory::class);
+    /** @var Auth&\Mockery\MockInterface $auth */
     $auth = \Mockery::mock(Auth::class);
 
     $now = new DateTimeImmutable();
@@ -79,9 +84,12 @@ test('sendConfirmation uses auth hash of subscription email as token', function 
  * @throws AssertionFailedError
  * @throws \InvalidArgumentException
  */
-test('sendPostToSubscribers calls sender for each subscription', function (): void {
+test('sendPostsToSubscribers calls sender for each subscription', function (): void {
+    /** @var Sender&\Mockery\MockInterface $sender */
     $sender = \Mockery::mock(Sender::class);
+    /** @var EmailTemplateFactory&\Mockery\MockInterface $emailTemplateFactory */
     $emailTemplateFactory = \Mockery::mock(EmailTemplateFactory::class);
+    /** @var Auth&\Mockery\MockInterface $auth */
     $auth = \Mockery::mock(Auth::class);
 
     $now = new DateTimeImmutable();
@@ -91,19 +99,19 @@ test('sendPostToSubscribers calls sender for each subscription', function (): vo
     $sub1 = new Subscription('https://example.com/feed', 'user1@example.com');
     $sub2 = new Subscription('https://example.com/feed', 'user2@example.com');
 
-    $template1 = new NewsletterTemplate($sub1, $feed, $post, 'https://example.com/cancel/user1');
-    $template2 = new NewsletterTemplate($sub2, $feed, $post, 'https://example.com/cancel/user2');
+    $template1 = new NewsletterTemplate($sub1, $feed, [$post], 'https://example.com/cancel/user1');
+    $template2 = new NewsletterTemplate($sub2, $feed, [$post], 'https://example.com/cancel/user2');
 
     $auth->shouldReceive('hash')->twice()->andReturn('token1', 'token2');
 
     $emailTemplateFactory
         ->shouldReceive('createNewsletter')
-        ->with($sub1, $feed, $post, 'token1')
+        ->with($sub1, $feed, [$post], 'token1')
         ->once()
         ->andReturn($template1);
     $emailTemplateFactory
         ->shouldReceive('createNewsletter')
-        ->with($sub2, $feed, $post, 'token2')
+        ->with($sub2, $feed, [$post], 'token2')
         ->once()
         ->andReturn($template2);
 
@@ -111,11 +119,14 @@ test('sendPostToSubscribers calls sender for each subscription', function (): vo
     $sender->shouldReceive('send')->with($template2)->once();
 
     $newsletter = new Newsletter($sender, $emailTemplateFactory, $auth);
-    $newsletter->sendPostToSubscribers($feed, $post, $sub1, $sub2);
+    $newsletter->sendPostsToSubscribers($feed, [$post], $sub1, $sub2);
 });
-test('sendPostToSubscribers creates correct template per subscription', function (): void {
+test('sendPostsToSubscribers creates correct template per subscription', function (): void {
+    /** @var Sender&\Mockery\MockInterface $sender */
     $sender = \Mockery::mock(Sender::class);
+    /** @var EmailTemplateFactory&\Mockery\MockInterface $emailTemplateFactory */
     $emailTemplateFactory = \Mockery::mock(EmailTemplateFactory::class);
+    /** @var Auth&\Mockery\MockInterface $auth */
     $auth = \Mockery::mock(Auth::class);
 
     $now = new DateTimeImmutable();
@@ -124,20 +135,20 @@ test('sendPostToSubscribers creates correct template per subscription', function
 
     $sub = new Subscription('https://example.com/feed', 'alice@example.com');
 
-    $template = new NewsletterTemplate($sub, $feed, $post, 'https://example.com/cancel/alice');
+    $template = new NewsletterTemplate($sub, $feed, [$post], 'https://example.com/cancel/alice');
 
     $auth->shouldReceive('hash')->andReturn('token-for-alice');
 
     $emailTemplateFactory
         ->shouldReceive('createNewsletter')
-        ->with($sub, $feed, $post, 'token-for-alice')
+        ->with($sub, $feed, [$post], 'token-for-alice')
         ->once()
         ->andReturn($template);
 
     $sender->shouldReceive('send')->with($template)->once();
 
     $newsletter = new Newsletter($sender, $emailTemplateFactory, $auth);
-    $newsletter->sendPostToSubscribers($feed, $post, $sub);
+    $newsletter->sendPostsToSubscribers($feed, [$post], $sub);
 });
 
 

--- a/tests/Models/SubscriptionsTest.php
+++ b/tests/Models/SubscriptionsTest.php
@@ -344,7 +344,7 @@ it('sendScheduled gets scheduled feeds, fetches posts, and sends to subscribers'
         ->with($feedWithPosts)
         ->andReturn([$activeSub1, $activeSub2]);
 
-    $newsletter->shouldReceive('sendPostToSubscribers')->once()->with($feedWithPosts, $post1, $activeSub1, $activeSub2);
+    $newsletter->shouldReceive('sendPostsToSubscribers')->once()->with($feedWithPosts, [$post1], $activeSub1, $activeSub2);
 
     $feeds->shouldReceive('updateLastSentPost')->once()->with($feedWithPosts, $post1);
 
@@ -385,7 +385,52 @@ it('sendScheduled skips already-sent posts', function (): void {
     $feeds->shouldReceive('retrieveWithPosts')->once()->with($scheduledFeed)->andReturn($feedWithPosts);
 
     $subscriptionsDAO->shouldNotReceive('findActiveSubscriptionsFor');
-    $newsletter->shouldNotReceive('sendPostToSubscribers');
+    $newsletter->shouldNotReceive('sendPostsToSubscribers');
+    $feeds->shouldNotReceive('updateLastSentPost');
+
+    $subs = new Subscriptions($subscriptionsDAO, $feeds, $newsletter, $auth);
+
+    $subs->sendScheduled($datetime);
+});
+
+/**
+ * Regression: when the newest post was already sent (lastSentPostUri points at
+ * posts[0]), older posts must NOT be re-emailed. Previously `continue` skipped
+ * the watermark and then sent the next (older) post, regressing the watermark.
+ *
+ * @throws EndUserException
+ * @throws \Random\RandomException
+ */
+it('sendScheduled does not resend older posts once the newest is sent', function (): void {
+    /** @var SubscriptionsDAO&\Mockery\MockInterface $subscriptionsDAO */
+    $subscriptionsDAO = \Mockery::mock(SubscriptionsDAO::class);
+    /** @var Feeds&\Mockery\MockInterface $feeds */
+    $feeds = \Mockery::mock(Feeds::class);
+    /** @var Newsletter&\Mockery\MockInterface $newsletter */
+    $newsletter = \Mockery::mock(Newsletter::class);
+    /** @var Auth&\Mockery\MockInterface $auth */
+    $auth = \Mockery::mock(Auth::class);
+
+    $datetime = new DateTimeImmutable();
+    $feedUri = 'https://example.com/feed';
+
+    $scheduledFeed = new Feed(new FeedMetadata($feedUri, 'Scheduled Feed', 'https://example.com', $datetime));
+
+    // Newest-first: the newest post was already sent (it is the watermark),
+    // an older post is still present in the feed.
+    $newest = new Post('https://example.com/newest', 'Newest', 'Content newest');
+    $older = new Post('https://example.com/older', 'Older', 'Content older');
+    $feedWithPosts = new Feed(
+        metadata: new FeedMetadata($feedUri, 'Scheduled Feed', 'https://example.com', $datetime),
+        lastSentPostUri: 'https://example.com/newest',
+        posts: [$newest, $older],
+    );
+
+    $feeds->shouldReceive('getScheduled')->once()->with($datetime)->andReturn([$scheduledFeed]);
+    $feeds->shouldReceive('retrieveWithPosts')->once()->with($scheduledFeed)->andReturn($feedWithPosts);
+
+    $subscriptionsDAO->shouldNotReceive('findActiveSubscriptionsFor');
+    $newsletter->shouldNotReceive('sendPostsToSubscribers');
     $feeds->shouldNotReceive('updateLastSentPost');
 
     $subs = new Subscriptions($subscriptionsDAO, $feeds, $newsletter, $auth);
@@ -450,9 +495,9 @@ it('sendScheduled handles multiple scheduled feeds', function (): void {
         });
 
     $newsletter
-        ->shouldReceive('sendPostToSubscribers')
+        ->shouldReceive('sendPostsToSubscribers')
         ->times(2)
-        ->andReturnUsing(function (Feed $feed, Post $post, Subscription ...$subs) use (
+        ->andReturnUsing(function (Feed $feed, array $posts, Subscription ...$subs) use (
             $feedWithPosts1,
             $feedWithPosts2,
             $post1,
@@ -460,10 +505,10 @@ it('sendScheduled handles multiple scheduled feeds', function (): void {
             $sub1,
             $sub2,
         ): void {
-            if ($feed === $feedWithPosts1 && $post === $post1 && $subs === [$sub1]) {
+            if ($feed === $feedWithPosts1 && $posts === [$post1] && $subs === [$sub1]) {
                 return;
             }
-            if ($feed === $feedWithPosts2 && $post === $post2 && $subs === [$sub2]) {
+            if ($feed === $feedWithPosts2 && $posts === [$post2] && $subs === [$sub2]) {
                 return;
             }
         });
@@ -484,6 +529,56 @@ it('sendScheduled handles multiple scheduled feeds', function (): void {
                 return;
             }
         });
+
+    $subs = new Subscriptions($subscriptionsDAO, $feeds, $newsletter, $auth);
+
+    $subs->sendScheduled($datetime);
+});
+
+/**
+ * Sends every post newer than the watermark in a single email (newest-first),
+ * advancing the watermark to the newest sent post.
+ *
+ * @throws EndUserException
+ * @throws \Random\RandomException
+ */
+it('sendScheduled sends all new posts in one email', function (): void {
+    /** @var SubscriptionsDAO&\Mockery\MockInterface $subscriptionsDAO */
+    $subscriptionsDAO = \Mockery::mock(SubscriptionsDAO::class);
+    /** @var Feeds&\Mockery\MockInterface $feeds */
+    $feeds = \Mockery::mock(Feeds::class);
+    /** @var Newsletter&\Mockery\MockInterface $newsletter */
+    $newsletter = \Mockery::mock(Newsletter::class);
+    /** @var Auth&\Mockery\MockInterface $auth */
+    $auth = \Mockery::mock(Auth::class);
+
+    $datetime = new DateTimeImmutable();
+    $feedUri = 'https://example.com/feed';
+
+    $scheduledFeed = new Feed(new FeedMetadata($feedUri, 'Scheduled Feed', 'https://example.com', $datetime));
+
+    // Newest-first; the oldest is the watermark (already sent).
+    $newest = new Post('https://example.com/newest', 'Newest', 'Newest content');
+    $middle = new Post('https://example.com/middle', 'Middle', 'Middle content');
+    $watermark = new Post('https://example.com/old', 'Old', 'Old content');
+    $feedWithPosts = new Feed(
+        metadata: new FeedMetadata($feedUri, 'Scheduled Feed', 'https://example.com', $datetime),
+        lastSentPostUri: 'https://example.com/old',
+        posts: [$newest, $middle, $watermark],
+    );
+
+    $activeSub = new Subscription($feedUri, 'user@example.com', true);
+
+    $feeds->shouldReceive('getScheduled')->once()->with($datetime)->andReturn([$scheduledFeed]);
+    $feeds->shouldReceive('retrieveWithPosts')->once()->with($scheduledFeed)->andReturn($feedWithPosts);
+
+    $subscriptionsDAO->shouldReceive('findActiveSubscriptionsFor')->once()->with($feedWithPosts)->andReturn([$activeSub]);
+
+    // Exactly one email containing both new posts (newest-first).
+    $newsletter->shouldReceive('sendPostsToSubscribers')->once()->with($feedWithPosts, [$newest, $middle], $activeSub);
+
+    // Watermark advances to the newest sent post.
+    $feeds->shouldReceive('updateLastSentPost')->once()->with($feedWithPosts, $newest);
 
     $subs = new Subscriptions($subscriptionsDAO, $feeds, $newsletter, $auth);
 

--- a/tests/Templates/Email/NewsletterTest.php
+++ b/tests/Templates/Email/NewsletterTest.php
@@ -14,7 +14,7 @@ test('Newsletter recipient returns subscription email', function (): void {
         new FeedMetadata('https://example.com/feed', 'Blog Title', 'https://example.com', new \DateTimeImmutable()),
     );
     $post = new Post('https://example.com/post', 'Post Title', '<p>content html</p>');
-    $newsletter = new Newsletter($subscription, $feed, $post, 'https://example.com/cancel');
+    $newsletter = new Newsletter($subscription, $feed, [$post], 'https://example.com/cancel');
 
     expect($newsletter->recipient())->toBe('user@example.com');
 });
@@ -25,7 +25,7 @@ test('Newsletter subject combines post title and feed title', function (): void 
         new FeedMetadata('https://example.com/feed', 'Blog Title', 'https://example.com', new \DateTimeImmutable()),
     );
     $post = new Post('https://example.com/post', 'Post Title', '<p>content html</p>');
-    $newsletter = new Newsletter($subscription, $feed, $post, 'https://example.com/cancel');
+    $newsletter = new Newsletter($subscription, $feed, [$post], 'https://example.com/cancel');
 
     expect($newsletter->subject())->toBe('Post Title - Blog Title');
 });
@@ -36,12 +36,34 @@ test('Newsletter body contains post uri and cancellation uri', function (): void
         new FeedMetadata('https://example.com/feed', 'Blog Title', 'https://example.com', new \DateTimeImmutable()),
     );
     $post = new Post('https://example.com/post', 'Post Title', '<p>content html</p>');
-    $newsletter = new Newsletter($subscription, $feed, $post, 'https://example.com/cancel');
+    $newsletter = new Newsletter($subscription, $feed, [$post], 'https://example.com/cancel');
 
     $body = $newsletter->body();
     expect($body)->toContain('https://example.com/post');
     expect($body)->toContain('https://example.com/cancel');
     expect($body)->toContain('<p>content html</p>');
+});
+
+test('Newsletter renders multiple posts separated and with digest subject', function (): void {
+    $subscription = new Subscription('https://example.com/feed', 'user@example.com');
+    $feed = new Feed(
+        new FeedMetadata('https://example.com/feed', 'Blog Title', 'https://example.com', new \DateTimeImmutable()),
+    );
+    $newest = new Post('https://example.com/newest', 'Newest Title', '<p>newest</p>');
+    $older = new Post('https://example.com/older', 'Older Title', '<p>older</p>');
+    $newsletter = new Newsletter($subscription, $feed, [$newest, $older], 'https://example.com/cancel');
+
+    expect($newsletter->subject())->toBe('Newest Title (+1 more) - Blog Title');
+
+    $body = $newsletter->body();
+    expect($body)->toContain('Newest Title');
+    expect($body)->toContain('https://example.com/newest');
+    expect($body)->toContain('<p>newest</p>');
+    expect($body)->toContain('Older Title');
+    expect($body)->toContain('https://example.com/older');
+    expect($body)->toContain('<p>older</p>');
+    expect($body)->toContain('<hr');
+    expect($body)->toContain('https://example.com/cancel');
 });
 
 


### PR DESCRIPTION
## What & why

Scheduled delivery had two problems:

1. **Bug** — `sendScheduled` used `continue` (instead of `break`) when it hit the last-sent post (`last_sent_post_uri`). Since posts arrive newest→oldest, this *skipped* the already-sent newest post and kept mailing **older** posts, regressing the watermark and re-sending stale content on every run.
2. **Behavior** — each run emailed only one post; multiple new posts between runs were never delivered together.

## Change

`sendScheduled` now **collects every post newer than the watermark** (stopping at it), and sends them together in **one digest email per subscriber**, then advances the watermark to the newest sent post.

- `Templates/Email/Newsletter` — takes a `non-empty-list<Post>`; subject is `"Title - Feed"` (1 post) or `"First Title (+N more) - Feed"` (N posts); body renders one `<article>` per post (title links to the original), separated by an `<hr>`.
- `EmailTemplateFactory::createNewsletter` — takes a posts array.
- `Models\Newsletter` — `sendPostToSubscribers` → `sendPostsToSubscribers` (one email per subscriber, all posts).
- **First delivery** (no watermark): sends only the newest post, so a new subscriber isn't mailed the entire backlog.
- `findActiveSubscriptionsFor` is now called once per feed (was once per post).

## Verification

- `mago analyze` clean on all changed source/test files (non-empty-list<Post> propagated through the whole chain; Mockery mocks annotated).
- 100 unit/integration tests pass, incl. two new regression tests:
  - `sendScheduled sends all new posts in one email`
  - `Newsletter renders multiple posts separated and with digest subject`
- Smoke-tested the rendered output: digest subject + multi-`<article>` body with `<hr>` separators + unsubscribe link.

## Specs

Updated `specs/newsletter-delivery.md` and `specs/core-architecture.md` to reflect the consolidated digest delivery.

> Note: the term `watermark` is used throughout (the cursor tracking the last-sent post = `last_sent_post_uri`).