### PR TITLE
fix(lint): resolve mago lint warnings

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 return (
     /** @return array<string, string> */
     static function (): array {
-        $dbPath = \getenv('NEWSLETTER_DB_PATH') ?: __DIR__ . '/../data/database.sqlite3';
+        $dbPath = \getenv('NEWSLETTER_DB_PATH');
+        if ($dbPath === false || $dbPath === '') {
+            $dbPath = __DIR__ . '/../data/database.sqlite3';
+        }
         return [
             'dsn' => 'sqlite:' . $dbPath,
         ];

--- a/public/index.php
+++ b/public/index.php
@@ -8,7 +8,7 @@
     <meta name="author" content="Ivan Yaki">
     <meta name="description" content="Transform any RSS or Atom feed into an email newsletter. Free, privacy-friendly, double opt-in. No RSS reader needed.">
     <meta name="robots" content="index, follow">
-    <link rel="canonical" href="<?= rtrim(\getenv('URI_SELF') ?: '', '/') ?>">
+    <link rel="canonical" href="<?= rtrim((string) \getenv('URI_SELF'), characters: '/') ?>">
     <meta property="og:title" content="Simple Newsletter - RSS & Atom to Email">
     <meta property="og:description" content="Convert RSS or Atom feeds into email newsletters. Free, privacy-friendly, double opt-in. No account required.">
     <meta property="og:url" content="<?= \getenv('URI_SELF') ?>">
@@ -49,7 +49,7 @@
         "@type": "WebApplication",
         "name": "Simple Newsletter",
         "description": "Free service that converts RSS and Atom feeds into email newsletters",
-        "url": "<?= rtrim(\getenv('URI_SELF') ?: '', '/') ?>",
+        "url": "<?= rtrim((string) \getenv('URI_SELF'), characters: '/') ?>",
         "applicationCategory": "Utility",
         "operatingSystem": "Web",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },


### PR DESCRIPTION
## Summary

Clears all 5 remaining `mago lint` warnings (`mago analyze` was already clean):

- **`config/database.php`** — shorthand ternary `?:` replaced with an explicit `false`/`''` check. `getenv()` returns `false` (not `null`) when unset, so the suggested `??` coalesce would have broken the fallback path.
- **`public/index.php`** — `\getenv('URI_SELF') ?: ''` replaced with a `(string)` cast (identical semantics: `false` → `''`), and the literal `'/'` passed to `rtrim()` as the named argument `characters:`.

## Verification

- `vendor/bin/mago lint` → no issues
- `vendor/bin/mago analyze` → no issues
- Smoke-tested `config/database.php` DSN with `NEWSLETTER_DB_PATH` set and unset — both resolve correctly
- Pre-commit hooks (mago lint + analyze) passed